### PR TITLE
Fix syntax highlighitng in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,11 @@ Set custom files and entire folders to ignore within your `/docs` folder. For fi
 ###Disabling clean URLs
 By default, Daux.io will create clean url's that do not include index.php. On servers running Apache, uploading the included .htaccess file should be enough for them to work properly. On servers that are not running Apache or that do not allow custom .htaccess files, you may need to disable clean_urls:
 
-	{
+```json
+{
 		"clean_urls": false
-	}
+}
+```
 
 ## Running Remotely
 

--- a/docs/00_Getting_Started.md
+++ b/docs/00_Getting_Started.md
@@ -170,9 +170,11 @@ Set custom files and entire folders to ignore within your `/docs` folder. For fi
 ###Disabling clean URLs
 By default, Daux.io will create clean url's that do not include index.php. On servers running Apache, uploading the included .htaccess file should be enough for them to work properly. On servers that are not running Apache or that do not allow custom .htaccess files, you may need to disable clean_urls:
 
-	{
+```json
+{
 		"clean_urls": false
-	}
+}
+```
 
 ## Running Remotely
 


### PR DESCRIPTION
To match the highlighting that was recently merged in the rest of the document.
