### PR TITLE
Fixed collapse button on mobile menu: included missing bootstrap js

### DIFF
--- a/css/daux-blue.css
+++ b/css/daux-blue.css
@@ -6508,8 +6508,15 @@ body {
     display: block;
   }
 }
-@media (max-width: 480px) {
-  
+@media (max-width: 768px) {
+  .sub-nav-collapse {
+    display: none;
+  }
+}
+@media (min-width: 768px) {
+  .sub-nav-collapse {
+    display: block;
+  }
 }
 @media only screen and (max-width: 800px) {
   /* Force table to not be like tables anymore */

--- a/css/daux-green.css
+++ b/css/daux-green.css
@@ -6508,8 +6508,15 @@ body {
     display: block;
   }
 }
-@media (max-width: 480px) {
-  
+@media (max-width: 768px) {
+  .sub-nav-collapse {
+    display: none;
+  }
+}
+@media (min-width: 768px) {
+  .sub-nav-collapse {
+    display: block;
+  }
 }
 @media only screen and (max-width: 800px) {
   /* Force table to not be like tables anymore */

--- a/css/daux-navy.css
+++ b/css/daux-navy.css
@@ -6508,8 +6508,15 @@ body {
     display: block;
   }
 }
-@media (max-width: 480px) {
-  
+@media (max-width: 768px) {
+  .sub-nav-collapse {
+    display: none;
+  }
+}
+@media (min-width: 768px) {
+  .sub-nav-collapse {
+    display: block;
+  }
 }
 @media only screen and (max-width: 800px) {
   /* Force table to not be like tables anymore */

--- a/css/daux-red.css
+++ b/css/daux-red.css
@@ -6508,8 +6508,15 @@ body {
     display: block;
   }
 }
-@media (max-width: 480px) {
-  
+@media (max-width: 768px) {
+  .sub-nav-collapse {
+    display: none;
+  }
+}
+@media (min-width: 768px) {
+  .sub-nav-collapse {
+    display: block;
+  }
 }
 @media only screen and (max-width: 800px) {
   /* Force table to not be like tables anymore */

--- a/index.php
+++ b/index.php
@@ -238,13 +238,13 @@ if ($homepage && $homepage_url !== '/') {
 				<div class="left-column article-tree span3">
 					<!-- For Mobile -->
 					<div class="responsive-collapse">
-						<button type="button" class="btn btn-sidebar" data-toggle="collapse" data-target="#sub-nav-collapse">
+						<button type="button" class="btn btn-sidebar" id="menu-spinner-button">
 					        <span class="icon-bar"></span>
 					        <span class="icon-bar"></span>
 					        <span class="icon-bar"></span>
 					    </button>
 					</div>
-					<div id="sub-nav-collapse" class="collapse in">
+					<div id="sub-nav-collapse" class="sub-nav-collapse">
 						<!-- Navigation -->
 						<?php echo build_nav($tree); ?>
 

--- a/js/custom.js
+++ b/js/custom.js
@@ -8,16 +8,15 @@ $(function() {
 	// Bootstrap Table Class
 	$('table').addClass('table');
 
-	var mobileNavWorkaround = function() {
-		if($(window).width()< 768) {
-			$('#sub-nav-collapse').css('height', '0px');
-		} else {
-			$('#sub-nav-collapse').css('height', 'auto');
-		}
-	}
-
-	$(window).resize(function() {
-		mobileNavWorkaround();
+	// Responsive menu spinner
+	$('#menu-spinner-button').click(function() {
+		$('#sub-nav-collapse').slideToggle();
 	});
-	mobileNavWorkaround();
+
+	// Catch browser resize
+	$(window).resize(function() {
+		// Remove transition inline style on large screens
+		if ($(window).width() >= 768)
+			$('#sub-nav-collapse').removeAttr('style');
+	});
 });

--- a/less/import/daux-base.less
+++ b/less/import/daux-base.less
@@ -265,8 +265,11 @@ html, body {
 	}
 }
 .sub-nav-collapse {
-	@media (max-width: 480px) {
-		//display: none;
+	@media (max-width: 768px) {
+		display: none;
+	}
+	@media (min-width: 768px) {
+		display: block;
 	}
 }
 


### PR DESCRIPTION
This makes the collapse button work, may need looking into for when stretching chrome window to larger viewport, as a closed menu does not open on large screens when the display size is increased.
