### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "authors": [
         {
             "name": "Justin Walsh",
-            "site": "http://todaymade.com/"
+            "homepage": "http://todaymade.com/"
         }
     ],
     "require": {


### PR DESCRIPTION
Every php developer has composer and could use it.
For install daux.io require just one command:
`composer create-project justinwalsh/daux.io path/to/docs -s dev`
If PR will merged, you should add it to [Packagist](http://packagist.org)
Also you can satisfy dependencies(markdown) through composer
