### PR TITLE
Created option for breadcrumb style titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ By default, Daux.io will create clean url's that do not include index.php. On se
 }
 ```
 
+###Breadcrumb titles
+Daux.io provides the option to present page titles as breadcrumb navigation.
+
+```json
+{
+		"breadcrumbs": true
+}
+```
+
 ###Date Modified
 By default, daux.io will display the last modified time as reported by the system underneath the title for each document. To disable this, change the option in your config.json to false.
 

--- a/libs/functions.php
+++ b/libs/functions.php
@@ -30,7 +30,8 @@
             'ignore' => array(),
             'languages' => array(),
             'file_editor' => false,
-            'template' => 'default'
+            'template' => 'default',
+            'breadcrumbs' => false
         );
 
         // Load User Config
@@ -165,9 +166,13 @@
             $page['modified'] = filemtime($file);
 
             $Parsedown = new Parsedown();
-
             $page['content'] =  $Parsedown->text($page['markdown']);
-            $page['title'] = clean_url($file, 'Title');
+
+            if ($options['breadcrumbs']) {
+                $page['title'] = url_to_title(get_url($file), 'Colons');
+            } else {
+                $page['title'] = clean_url($file, 'Title');                
+            }
         }
         $relative_base = ($mode === 'Static') ? relative_path("", $file) : "http://" . $base_path . '/';
         ob_start();
@@ -175,6 +180,26 @@
         $return = ob_get_contents();
         @ob_end_clean();
         return $return;
+    }
+
+    // Converts a URL to a readable breadcrumb string for the page title
+    function url_to_title($url, $separator = "Chevrons") {
+        $url = str_replace("index.php?", "", $url);
+        $url = str_replace("_", " ", $url);
+        switch ($separator) {
+            case 'Chevrons':
+                $url = str_replace("/", " <i class=\"glyphicon glyphicon-chevron-right\"></i> ", $url);
+                return $url;
+            case 'Colons':
+                $url = str_replace("/", ": ", $url); 
+                return $url;
+            case 'Spaces':
+                $url = str_replace("/", " ", $url); 
+                return $url;
+
+        }
+
+        return $url;
     }
 
     //  File to URL


### PR DESCRIPTION
This is a small update that would allow users to opt-in to having their titles display in a breadcrumb style form. I work with a version of daux that has a decent number of folders/subfolders and it seems like this addition other people want (addresses issue #150).
I also added a quick explanation on how to turn it on using the config.json

Let me know what you think
