### PR TITLE
fixed issue where numbers are incorrectly stripped from urls

### DIFF
--- a/libs/functions.php
+++ b/libs/functions.php
@@ -203,7 +203,7 @@
     }
 
     //  File to URL
-    function clean_url($url, $mode = 'Static') {
+    function clean_url($url, $mode = 'Static', $from_link=false) {
         global $docs_path, $output_path, $options;
         switch ($mode) {
             case 'Live':
@@ -216,7 +216,7 @@
                 $url = explode('/', $url);
                 foreach ($url as &$a) {
                     $a = explode('_', $a);
-                    if (isset($a[0]) && is_numeric($a[0])) unset($a[0]);
+                    if (isset($a[0]) && is_numeric($a[0]) && !$from_link) unset($a[0]);
                     $a = implode('_', $a);
                 }
                 $url = implode('/', $url);

--- a/libs/live.php
+++ b/libs/live.php
@@ -27,7 +27,7 @@
     //  Get File from $url
     function getfile($tree, $url, $current_dir, $flag = FALSE) {
         global $docs_path, $base_doc, $options;
-        $url = clean_url($url, "Live");
+        $url = clean_url($url, "Live", true);
         if ($url === '' || $url === 'index') {
             if (is_file($docs_path . "/index.md")) return $docs_path . "/index.md";
             else {


### PR DESCRIPTION
Fixes #184
When getfile() calls clean_url(), numbers should not be stripped from the front of the title. I added a bool which checks for this case
