### PR TITLE
fix base path to work locally with clean urls

### DIFF
--- a/index.php
+++ b/index.php
@@ -90,7 +90,9 @@ if(isset($argv)){
     exit();
 }
 require_once(dirname( __FILE__)."/libs/live.php");
-$base_path = str_replace("/index.php", "", $_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']);
+$server_base = $_SERVER['HTTP_HOST'];
+if (!$options['clean_urls']) $server_base .= $_SERVER['PHP_SELF'];
+$base_path = str_replace("/index.php", "", $server_base);
 define("CLI", FALSE);
 build_tree();
 $remove = array($base_path . '/');


### PR DESCRIPTION
Currently daux does not work when run locally without disabling clean_urls due to an issue with $relative_url and $base_path. It's confusing for some people when they first start using daux and in general I thought it was valuable to fix it. Now clean urls will only affect the url scheme and not the ability to run it locally

addresses https://github.com/justinwalsh/daux.io/issues/152
and also https://github.com/justinwalsh/daux.io/issues/140

before: run locally with clean urls on
![](https://cloud.githubusercontent.com/assets/1336484/2641019/d1d9bb02-bef2-11e3-9d0f-642929658d30.png)

after: run locally with clean urls on or off
![screen shot 2014-08-07 at 2 11 00 pm](https://cloud.githubusercontent.com/assets/1421384/3846657/adec9d7e-1e5e-11e4-99cd-c5a9e06464de.png)
