### PR TITLE
Resolve theme issues with https behind reverse proxy

### DIFF
--- a/libs/daux.php
+++ b/libs/daux.php
@@ -198,8 +198,7 @@
                     $params['error_type'] = ErrorPage::NORMAL_ERROR_TYPE;
                     $params['index_key'] = 'index';
                     $params['docs_path'] = $this->docs_path;
-                    $protocol = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443) ?
-                        'https://' : 'http://';
+                    $protocol = '//';
                     $params['base_url'] = $protocol . $this->base_url . '/';
                     $params['base_page'] = $params['base_url'];
                     $params['host'] = $this->host;
@@ -228,8 +227,7 @@
                 case Daux::LIVE_MODE:
                     $params['docs_path'] = $this->docs_path;
                     $params['index_key'] = 'index';
-                    $protocol = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443) ?
-                        'https://' : 'http://';
+                    $protocol = '//';
                     $params['base_url'] = $protocol . $this->base_url . '/';
                     $params['base_page'] = $params['base_url'];
                     $params['host'] = $this->host;

--- a/themes/daux-blue.thm
+++ b/themes/daux-blue.thm
@@ -1,7 +1,7 @@
 {
     "favicon": "<base_url>themes/daux-blue/img/favicon-blue.png",
     "css": ["<base_url>themes/daux-blue/css/daux-blue.css"],
-    "fonts": ["http://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&subset=latin,cyrillic-ext,cyrillic"],
+    "fonts": ["//fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&subset=latin,cyrillic-ext,cyrillic"],
     "js": [],
     "require-jquery": true,
     "bootstrap-js": false

--- a/themes/daux-green.thm
+++ b/themes/daux-green.thm
@@ -1,7 +1,7 @@
 {
     "favicon": "<base_url>themes/daux-green/img/favicon-green.png",
     "css": ["<base_url>themes/daux-green/css/daux-green.css"],
-    "fonts": ["http://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&subset=latin,cyrillic-ext,cyrillic"],
+    "fonts": ["//fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&subset=latin,cyrillic-ext,cyrillic"],
     "js": [],
     "require-jquery": true,
     "bootstrap-js": false

--- a/themes/daux-navy.thm
+++ b/themes/daux-navy.thm
@@ -1,7 +1,7 @@
 {
     "favicon": "<base_url>themes/daux-navy/img/favicon-navy.png",
     "css": ["<base_url>themes/daux-navy/css/daux-navy.css"],
-    "fonts": ["http://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&subset=latin,cyrillic-ext,cyrillic"],
+    "fonts": ["//fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&subset=latin,cyrillic-ext,cyrillic"],
     "js": [],
     "require-jquery": true,
     "bootstrap-js": false

--- a/themes/daux-red.thm
+++ b/themes/daux-red.thm
@@ -1,7 +1,7 @@
 {
     "favicon": "<base_url>themes/daux-red/img/favicon-red.png",
     "css": ["<base_url>themes/daux-red/css/daux-red.css"],
-    "fonts": ["http://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&subset=latin,cyrillic-ext,cyrillic"],
+    "fonts": ["//fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&subset=latin,cyrillic-ext,cyrillic"],
     "js": [],
     "require-jquery": true,
     "bootstrap-js": false


### PR DESCRIPTION
The changes in this request should resolve 2 theme issues we have ran into serving daux.io over https.
1. When terminating https at a reverse proxy the HTTPS $_server field is empty. This is correct as php is getting the request over http, however this makes links using <base_url> in the theme come back as http to the browser. This is problematic as many browsers such as Chrome won't serve http content on an https site.
2. The Roboto Slab font is always requested as http, causing it not to be loaded due to the same issue as above.

The fix we did was to change out the protocol with //. 

Let me know if you have any questions.

Thanks,
Justin C.
