### PR TITLE
fixed index from always being used rather than first_page

### DIFF
--- a/libs/daux.php
+++ b/libs/daux.php
@@ -46,6 +46,9 @@
             $request = DauxHelper::get_request();
             $request = urldecode($request);
             $request_type = isset($query['method']) ? $query['method'] : '';
+            if($request == 'first_page') {
+                $request = $this->tree->first_page->uri;
+            }
             switch ($request_type) {
                 case 'DauxEdit':
                     if ($this->options['file_editor']) {
@@ -105,7 +108,7 @@
             if (!is_dir($this->docs_path) && !is_dir($this->docs_path = $this->local_base . DIRECTORY_SEPARATOR . $this->docs_path)) {
                 $this->generate_error_page('Docs Directory not found',
                     'The Docs directory does not exist. Check the path again : ' . $this->docs_path, ErrorPage::FATAL_ERROR_TYPE);
-                return;                    
+                return;
             }
 
             if (!isset($global_config['valid_markdown_extensions'])) static::$VALID_MARKDOWN_EXTENSIONS = array('md', 'markdown');

--- a/libs/daux_helper.php
+++ b/libs/daux_helper.php
@@ -33,7 +33,7 @@
             if ($filename[0] == '' || is_numeric($filename[0])) unset($filename[0]);
             else {
                 $t = $filename[0];
-                if ($t[0] == '-') $filename[0] = substr($t, 1);                
+                if ($t[0] == '-') $filename[0] = substr($t, 1);
             }
             $filename = implode(' ', $filename);
             return $filename;
@@ -49,7 +49,7 @@
             if ($filename[0] == '' || is_numeric($filename[0])) unset($filename[0]);
             else {
                 $t = $filename[0];
-                if ($t[0] == '-') $filename[0] = substr($t, 1);                
+                if ($t[0] == '-') $filename[0] = substr($t, 1);
             }
             $filename = implode('_', $filename);
             return $filename;
@@ -97,12 +97,12 @@
             }
             else return false;
             $uri = str_replace(array('//', '../'), '/', trim($uri, '/'));
-            if ($uri == "") $uri = "index";
+            if ($uri == "") $uri = "first_page";
             return $uri;
         }
 
         public static function configure_theme($theme, $base_url, $local_base, $theme_url, $mode = Daux::LIVE_MODE) {
-            $name = static::pathinfo($theme); 
+            $name = static::pathinfo($theme);
             if (is_file($theme)) {
                 $theme = file_get_contents($theme);
                 $theme = json_decode($theme, true);
@@ -230,7 +230,7 @@ EOT;
                         $entry = new Directory_Entry($path, $new_parents);
                         if ($mode === Daux::STATIC_MODE) $entry->uri .= '.html';
                     }
-                    if ($entry instanceof Directory_Entry) $node->value[$entry->uri] = $entry; 
+                    if ($entry instanceof Directory_Entry) $node->value[$entry->uri] = $entry;
                 }
                 $node->sort();
                 $node->first_page = $node->get_first_page();


### PR DESCRIPTION
When I was trying to not use an index page I was getting a Page Not Found error. I found out that daux_helper sets the default request for a blank uri to index. What we actually want is to change a blank uri to the first_page->uri. I have made changes so that this will happen, and have stopped seeing the Page Not found error when not using index.md
