### PR TITLE
Adding Parsedown Extra syntax support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=5.3",
-        "erusev/parsedown": "~1.0"
+        "erusev/parsedown-extra": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.3",
+        "erusev/parsedown": "*",
         "erusev/parsedown-extra": "*"
     }
 }

--- a/docs/01_Examples/02_Markdown_Extra.md
+++ b/docs/01_Examples/02_Markdown_Extra.md
@@ -1,19 +1,24 @@
-## Markdown extra examples!!
+Here are some <a href="https://michelf.ca/projects/php-markdown/extra/">Markdown Extra</a> examples.
+
+>To view these, make sure you have turned on the Parsedown Extra support in the global.json file!
+
+#### Markdown inside a html block
 
 <div markdown="1">
 This is *true* markdown text.
 </div>
 
-Header 1            {#header1}
-========
+#### Header with an id attribute
 
-## Header 2 ##      {#header2}
+#### Header 2 ##      {#header2}
+
+#### Link to an HTML ID (#header1)
 
 [Link back to header 1](#header1)
 
-## The Site ##    {.main}
+#### Header with a class ##    {.main}
 
-## The Site ##    {.main .shine #the-site}
+#### Header with multiple classes and an id ##    {.main .shine #the-site}
 
 This is a paragraph introducing:
 
@@ -27,11 +32,55 @@ another code block
 
 ~~~
 
-blank line before
-blank line after
+blank line before the code block
 
 ~~~
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~ .html
-<p>paragraph <b>emphasis</b>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#### Simple table
+
+First Header  | Second Header
+------------- | -------------
+Content Cell  | Content Cell
+Content Cell  | Content Cell
+
+
+#### Table with aligned values
+
+| Item      | Value |
+| --------- | -----:|
+| Computer  | $1600 |
+| Phone     |   $12 |
+| Pipe      |    $1 |
+
+#### Code snippet/function definition
+
+| Function name | Description                    |
+| ------------- | ------------------------------ |
+| `help()`      | Display the help window.       |
+| `destroy()`   | **Destroy your computer!**     |
+
+#### Definition list
+
+Apple
+:   Pomaceous fruit of plants of the genus Malus in 
+    the family Rosaceae.
+
+Orange
+:   The fruit of an evergreen tree of the genus Citrus.
+
+
+#### Abbreviations
+
+*[HTML]: Hyper Text Markup Language
+*[W3C]:  World Wide Web Consortium
+
+HTML
+
+W3C
+
+#### Footnotes
+
+That's some text with a footnote.[^1]
+
+
+[^1]: And that's the footnote.

--- a/docs/01_Examples/02_Markdown_Extra.md
+++ b/docs/01_Examples/02_Markdown_Extra.md
@@ -1,0 +1,37 @@
+## Markdown extra examples!!
+
+<div markdown="1">
+This is *true* markdown text.
+</div>
+
+Header 1            {#header1}
+========
+
+## Header 2 ##      {#header2}
+
+[Link back to header 1](#header1)
+
+## The Site ##    {.main}
+
+## The Site ##    {.main .shine #the-site}
+
+This is a paragraph introducing:
+
+~~~~~~~~~~~~~~~~~~~~~
+a one-line code block
+~~~~~~~~~~~~~~~~~~~~~
+
+``````````````````
+another code block
+``````````````````
+
+~~~
+
+blank line before
+blank line after
+
+~~~
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~ .html
+<p>paragraph <b>emphasis</b>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/global.json
+++ b/global.json
@@ -1,4 +1,5 @@
 {
     "docs_directory": "docs",
-    "valid_markdown_extensions": ["md", "markdown"]
+    "valid_markdown_extensions": ["md", "markdown"],
+    "parsedown_extra_support": true
 }

--- a/libs/daux.php
+++ b/libs/daux.php
@@ -12,6 +12,7 @@
         const LIVE_MODE = 'DAUX_LIVE';
 
         public static $VALID_MARKDOWN_EXTENSIONS;
+        private $parsedown_extra_support = false;
         private $local_base;
         private $base_url;
         private $host;
@@ -113,6 +114,10 @@
 
             if (!isset($global_config['valid_markdown_extensions'])) static::$VALID_MARKDOWN_EXTENSIONS = array('md', 'markdown');
             else static::$VALID_MARKDOWN_EXTENSIONS = $global_config['valid_markdown_extensions'];
+
+            if(isset($global_config['parsedown_extra_support']) && $global_config['parsedown_extra_support'] === true) {
+                $this->parsedown_extra_support = true;
+            }
         }
 
         private function load_docs_config($config_file) {
@@ -235,6 +240,7 @@
                     $params['theme'] = DauxHelper::configure_theme($this->local_base . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR .
                         $this->options['template'] . DIRECTORY_SEPARATOR . 'themes' . DIRECTORY_SEPARATOR . $this->options['theme'] . '.thm', $params['base_url'],
                         $this->local_base, $params['base_url'] . "templates/" . $params['template'] . "/themes/" . $this->options['theme'] . '/');
+                    $params['parsedown_extra_support'] = $this->parsedown_extra_support;
                     break;
 
                 case Daux::LIVE_MODE:
@@ -283,6 +289,7 @@
                     $params['float'] = $this->options['float'];
                     $params['date_modified'] = $this->options['date_modified'];
                     $params['file_editor'] = $this->options['file_editor'];
+                    $params['parsedown_extra_support'] = $this->parsedown_extra_support;
                     break;
 
                 case Daux::STATIC_MODE:
@@ -326,6 +333,7 @@
                     $params['float'] = $this->options['float'];
                     $params['date_modified'] = $this->options['date_modified'];
                     $params['file_editor'] = false;
+                    $params['parsedown_extra_support'] = $this->parsedown_extra_support;
                     break;
             }
             return $params;

--- a/libs/daux_page.php
+++ b/libs/daux_page.php
@@ -161,7 +161,7 @@
 
         private function generate_page() {
             $params = $this->params;
-            $Parsedown = new \Parsedown();
+            $Parsedown = new \ParsedownExtra();
             if ($params['request'] === $params['index_key']) {
                 if ($params['multilanguage']) {
                     foreach ($params['languages'] as $key => $name) {

--- a/libs/daux_page.php
+++ b/libs/daux_page.php
@@ -161,7 +161,15 @@
 
         private function generate_page() {
             $params = $this->params;
-            $Parsedown = new \ParsedownExtra();
+            
+            $Parsedown = null;
+
+            if($this->params['parsedown_extra_support']) {
+                $Parsedown = new \ParsedownExtra();
+            } else {
+                $Parsedown = new \Parsedown();
+            }
+
             if ($params['request'] === $params['index_key']) {
                 if ($params['multilanguage']) {
                     foreach ($params['languages'] as $key => $name) {


### PR DESCRIPTION
I've had a go at implementing an optional [Parsedown Extra](https://github.com/erusev/parsedown-extra) support feature which can be turned on in the global.json file. It's a true or false value which defines which version of the Parsedown library will be used. Both libraries are listed as a dependancy, and shouldn't make much difference to the overall weight of the program. 

To enable support:
```"parsedown_extra_support": true```

Caveats: 
* Both libraries are required & loaded through the autoloader

All feedback is valuable! Please let me know what you think!