### PR TITLE
Update daux.php

### DIFF
--- a/libs/daux.php
+++ b/libs/daux.php
@@ -77,7 +77,7 @@
             }
             $this->mode = Daux::LIVE_MODE;
             $this->host = $_SERVER['HTTP_HOST'];
-            $this->base_url = $_SERVER['HTTP_HOST'] . dirname($_SERVER['PHP_SELF']);
+            $this->base_url = $_SERVER['HTTP_HOST'] . str_replace(dirname($_SERVER['PHP_SELF']),"\\","/");
             $t = strrpos($this->base_url, '/index.php');
             if ($t != FALSE) $this->base_url = substr($this->base_url, 0, $t);
             if (substr($this->base_url, -1) !== '/') $this->base_url .= '/';


### PR DESCRIPTION
On Windows the `dirname` function returns a backslash delimited string. This leads to assets not loading (like css). I've just added a simple replace function to swap the delimiters out.

see issue #264