### PR TITLE
Fixed title link for static files and fixed "float = false" not being obeyed.

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -26,19 +26,22 @@ function setCodeBlockStyle(x) {
     switch (x) {
         default:
         case 0:
-            toggleCodeBlockBtn.innerHTML = "Show Code Blocks Inline";
+            if(toggleCodeBlockBtn)
+              toggleCodeBlockBtn.innerHTML = "Show Code Blocks Inline";
             codeBlockView.addClass('float-view');
             codeBlocks.removeClass('hidden');
             break;
         case 1:
-            toggleCodeBlockBtn.innerHTML = "Hide Code Blocks";
+            if(toggleCodeBlockBtn)
+              toggleCodeBlockBtn.innerHTML = "Hide Code Blocks";
             codeBlockView.removeClass('float-view');
             codeBlocks.removeClass('hidden');
             break;
         case 2:
-            toggleCodeBlockBtn.innerHTML = "Show Code Blocks";
+            if(toggleCodeBlockBtn)
+              toggleCodeBlockBtn.innerHTML = "Show Code Blocks";
             codeBlockView.removeClass('float-view');
-            codeBlocks.addClass('hidden');          
+            codeBlocks.addClass('hidden');
             break;
     }
 }
@@ -56,7 +59,7 @@ $(function () {
     codeBlocks = $('.content-page article > pre');
     codeBlockState = localStorage.getItem("codeBlockState");
     if (!codeBlockState) {
-        codeBlockState = 0;
+        codeBlockState = (codeBlockView.hasClass('float-view')) ? 0 : 1;
         localStorage.setItem("codeBlockState", codeBlockState);
     } else codeBlockState = parseInt(codeBlockState);
     if (!codeBlockView.size()) return;

--- a/templates/default/default.tpl
+++ b/templates/default/default.tpl
@@ -65,6 +65,7 @@
             $homepage = $page['homepage'];
             $project_title = utf8_encode($params['title']);
             $index = utf8_encode($base_page . $params['index']->value);
+            if ($params['mode'] === \TodayMade\Daux\Daux::STATIC_MODE) $index .= '.html';
             $tree = $params['tree'];
             $entry_page = $page['entry_page'];
             ob_start();


### PR DESCRIPTION
The link in the header bar was on the generated static pages was giving a 404 because of missing '.html' extension. I added a simple check to add in 'default.tpl'.
I also have a fix for the reported issue of "float" not being listened to unless "toggle_code" was set to false too. I corrected the behavior so they work independently as expected. _However, since the setting is stored in browser local storage one may have to clear their local storage for the page to see the change take effect._
This commit fixes #246