### PR TITLE
Daux->local_base override from caller

### DIFF
--- a/index.php
+++ b/index.php
@@ -76,6 +76,7 @@ if (php_sapi_name() === 'cli-server') {
 }
 
 if (file_exists('vendor/autoload.php')) {
+    define('LOCAL_DIR', isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : __DIR__);
     require_once('vendor/autoload.php');
 } elseif (file_exists('daux.phar')) {
     define('PHAR_DIR', __DIR__);

--- a/libs/Daux.php
+++ b/libs/Daux.php
@@ -57,6 +57,11 @@ class Daux
 
         $this->local_base = $this->internal_base = dirname(__DIR__);
 
+        // If defined by the request environment
+        if (defined('LOCAL_DIR')) {
+            $this->local_base = LOCAL_DIR;
+        }
+
         // In case we're inside the phar archive
         // we save the path to the directory
         // in which it is contained


### PR DESCRIPTION
Added LOCAL_DIR constant for overriding the ->local_base being defined by the DIR value from the Daux library location.

Necessary to solve the current inability to override Daux->local_base once control handed to server.