### PR TITLE
Bugfix handling of folders with .names

### DIFF
--- a/libs/daux_helper.php
+++ b/libs/daux_helper.php
@@ -249,6 +249,13 @@ EOT;
             if (isset($m[2])) $ret['basename']=$m[2];
             if (isset($m[5])) $ret['extension']=$m[5];
             if (isset($m[3])) $ret['filename']=$m[3];
+
+            // handle folders like .foo
+            if (is_dir($path)) {
+                unset($ret['extension']);
+                $ret['filename'] = $ret['basename'];
+            }
+
             return $ret;
         }
 


### PR DESCRIPTION
There was a problem with folder names that start with a dot in the docs directory. Those weren't detected as folders but as a file.

The problem occured for me, because my IDE created some project files there.