### PR TITLE
Add support for extra buttons on the landing page

### DIFF
--- a/default.json
+++ b/default.json
@@ -23,5 +23,7 @@
         "folders": []
     },    
     "links": {
+    },
+    "buttons": {
     }
 }

--- a/docs/config.json
+++ b/docs/config.json
@@ -24,5 +24,8 @@
         "GitHub Repo": "https://github.com/justinwalsh/daux.io",
         "Help/Support/Bugs": "https://github.com/justinwalsh/daux.io/issues",
         "Made by Todaymade": "http://todaymade.com"
+    },
+    "buttons": {
+        "Download": "https://github.com/justinwalsh/daux.io/archive/master.zip"
     }
 }

--- a/libs/daux.php
+++ b/libs/daux.php
@@ -225,6 +225,7 @@
                     if ($params['image'] !== '') $params['image'] = str_replace('<base_url>', $params['base_url'], $params['image']);
                     $params['repo'] = $this->options['repo'];
                     $params['links'] = $this->options['links'];
+                    $params['buttons'] = $this->options['buttons'];
                     $params['twitter'] = $this->options['twitter'];
                     $params['google_analytics'] = ($g = $this->options['google_analytics']) ?
                         DauxHelper::google_analytics($g, $this->host) : '';
@@ -255,6 +256,7 @@
                     if ($params['image'] !== '') $params['image'] = str_replace('<base_url>', $params['base_url'], $params['image']);
                     $params['repo'] = $this->options['repo'];
                     $params['links'] = $this->options['links'];
+                    $params['buttons'] = $this->options['buttons'];
                     $params['twitter'] = $this->options['twitter'];
                     $params['google_analytics'] = ($g = $this->options['google_analytics']) ?
                         DauxHelper::google_analytics($g, $this->host) : '';
@@ -299,6 +301,7 @@
                     $params['image'] = $this->options['image'];
                     $params['repo'] = $this->options['repo'];
                     $params['links'] = $this->options['links'];
+                    $params['buttons'] = $this->options['buttons'];
                     $params['twitter'] = $this->options['twitter'];
                     $params['google_analytics'] = ($g = $this->options['google_analytics']) ?
                         DauxHelper::google_analytics($g, $this->host) : '';

--- a/templates/default/default.tpl
+++ b/templates/default/default.tpl
@@ -126,6 +126,7 @@
                         <?php
                             if ($params['repo']) echo '<a href="https://github.com/' . $params['repo'] . '" class="btn btn-secondary btn-hero">View On GitHub</a>';
                             foreach ($entry_page as $key => $node) echo '<a href="' . $node . '" class="btn btn-primary btn-hero">' . $key . '</a>';
+                            foreach ($params['buttons'] as $key => $node) echo '<a href="' . $node . '" class="btn btn-primary btn-hero">' . $key . '</a>';
                         ?>
                     </div>
                 </div>


### PR DESCRIPTION
I got a need for extra buttons on the landing page besides the View Documentation and View on Github buttons, with configurable destination URLs. The use case is to have the landing page as the main entrypoint for an application, with both "View Documentation" and "Get Started" buttons in the same place. 

This PR adds another config option called "buttons" (modeled after "links"), as a String => URL hash for extra buttons to the right of the default View Documentation button. Tested and works as expected for static page generation ("php generate.php").
