### PR TITLE
Add Cumulus TV to Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This is a list of sites using Daux.io:
 * [Sugoi](http://doc.sugoi.ventrux.com/)
 * [wallabag](http://doc.wallabag.org/index)
 * [iGeo-Topo](http://igeo-topo.fr/doc)
+* [Cumulus TV: Android TV app that turns any stream/page into a Live Channel](http://cumulustv.herokuapp.com)
 
 Do you use Daux.io? Send me a pull request or open an [issue](https://github.com/justinwalsh/daux.io/issues) and I will add you to the list.
 


### PR DESCRIPTION
Added a site run by @Fleker for his Android TV app, Cumulus TV, to the demos section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/justinwalsh/daux.io/378)
<!-- Reviewable:end -->
