### PR TITLE
Add support for anchors on internal links

### DIFF
--- a/libs/ContentTypes/Markdown/LinkRenderer.php
+++ b/libs/ContentTypes/Markdown/LinkRenderer.php
@@ -87,9 +87,18 @@ class LinkRenderer extends \League\CommonMark\Inline\Renderer\LinkRenderer
             return $element;
         }
 
+        // if there's a hash component in the url, ensure we
+        // don't put that part through the resolver.
+        $urlAndHash = explode("#", $url);
+        $url = $urlAndHash[0];
+
         $file = $this->resolveInternalFile($url);
 
         $url = DauxHelper::getRelativePath($this->daux->getCurrentPage()->getUrl(), $file->getUrl());
+
+        if(isset($urlAndHash[1])) {
+            $url .= "#" . $urlAndHash[1];
+        }
 
         $element->setAttribute('href', $url);
 


### PR DESCRIPTION
Hey there, great tool! :-)

I'm writing docs for a page that includes generated API documentation. I love that I can make an internal link to e.g. `[User](api/classes/user.html)` and Daux just picks it up.

However, I could not make links to fields or methods: writing `[User](api/classes/user.html#login)` caused a bunch of PHP errors. This PR should fix that by routing hash fragments around the resolver.