### PR TITLE
fix for error with mailto links

### DIFF
--- a/libs/ContentTypes/Markdown/LinkRenderer.php
+++ b/libs/ContentTypes/Markdown/LinkRenderer.php
@@ -65,7 +65,7 @@ class LinkRenderer extends \League\CommonMark\Inline\Renderer\LinkRenderer
 
     protected function isExternalUrl($url)
     {
-        return preg_match('|^(?:[a-z]+:)?//|', $url);
+        return preg_match('|^(?:[a-z]+:)?//|', $url) || substr($url, 0, 7) == "mailto:";
     }
 
     /**


### PR DESCRIPTION
treat [name@domain.com](mailto:name@domain.com) as external link
resolves #433 