### PR TITLE
define a category title different from directory name

### DIFF
--- a/libs/Tree/Directory.php
+++ b/libs/Tree/Directory.php
@@ -25,6 +25,11 @@ class Directory extends Entry implements \ArrayAccess, \IteratorAggregate
         foreach ($this->children as $key => $entry) {
             $name = $entry->getName();
 
+            if ($name == '_directory' && $entry->getTitle() != '') {
+              $this->title = $entry->getTitle();
+              continue;
+            }
+
             if ($name == 'index' || $name == '_index') {
                 $buckets['index'][$key] = $entry;
                 continue;


### PR DESCRIPTION
Allows to define a name for a category in the navigation tree different from the directory name. Works similar to defining an alternative file title

create a file named ```_directory.md``` with the following content

```
---
title: Your fancy category title
---
``` 