### PR TITLE
Fixed Markdown styling for third-tier heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you are interested in having a landing page for a subsection of your docs, al
 To customize the look and feel of your documentation, you can create a `config.json` file in the of the `/docs` folder.
 The `config.json` file is a simple JSON object that you can use to change some of the basic settings of the documentation.
 
-###Title:
+### Title
 Change the title bar in the docs
 
 ```json
@@ -126,7 +126,7 @@ Change the title bar in the docs
 }
 ```
 
-###Themes:
+### Themes
 We have 4 built-in Bootstrap themes. To use one of the themes, just set the `theme` option to one of the following:
 
 * daux-blue
@@ -142,7 +142,7 @@ We have 4 built-in Bootstrap themes. To use one of the themes, just set the `the
 }
 ```
 
-###Custom Theme:
+### Custom Theme
 To use a custom theme, just copy over the theme folder as well as the `.thm` file for that theme into the `themes` directory and set its value in the `theme` param in config.json
 
 ```json
@@ -151,7 +151,7 @@ To use a custom theme, just copy over the theme folder as well as the `.thm` fil
 }
 ```
 
-###Code Floating:
+### Code Floating
 By default your code blocks will be floated to a column on the right side of your content. To disable this feature, set the `float` property to `false`.
 
 ```json
@@ -160,7 +160,7 @@ By default your code blocks will be floated to a column on the right side of you
 }
 ```
 
-###Toggling Code Blocks
+### Toggling Code Blocks
 Some users might wish to hide the code blocks & view just the documentation. By setting the `toggle_code` property to `true`, you can offer a toggle button on the page.
 
 ```json
@@ -170,7 +170,7 @@ Some users might wish to hide the code blocks & view just the documentation. By 
 ```
 
 
-###GitHub Repo:
+### GitHub Repo
 Add a 'Fork me on GitHub' ribbon.
 
 ```json
@@ -179,7 +179,7 @@ Add a 'Fork me on GitHub' ribbon.
 }
 ```
 
-###Twitter:
+### Twitter
 Include twitter follow buttons in the sidebar.
 
 ```json
@@ -188,7 +188,7 @@ Include twitter follow buttons in the sidebar.
 }
 ```
 
-###Links:
+### Links
 Include custom links in the sidebar.
 
 ```json
@@ -201,7 +201,7 @@ Include custom links in the sidebar.
 }
 ```
 
-###Google Analytics:
+### Google Analytics
 This will embed the google analytics tracking code.
 
 ```json
@@ -210,7 +210,7 @@ This will embed the google analytics tracking code.
 }
 ```
 
-###Piwik Analytics:
+### Piwik Analytics
 This will embed the piwik tracking code.
 
 ```json
@@ -227,7 +227,7 @@ You can Also give a specific Piwik ID as well.
 }
 ```
 
-###Ignore:
+### Ignore
 Set custom files and entire folders to ignore within your `/docs` folder. For files make sure to include the file extension in the name. For both files and folders, names are case-sensitive.
 
 ```json
@@ -239,7 +239,7 @@ Set custom files and entire folders to ignore within your `/docs` folder. For fi
 	}
 ```
 
-###Breadcrumb titles
+### Breadcrumb titles
 Daux.io provides the option to present page titles as breadcrumb navigation. You can *optionally* specify the separator used for breadcrumbs.
 
 ```json
@@ -249,7 +249,7 @@ Daux.io provides the option to present page titles as breadcrumb navigation. You
 }
 ```
 
-###Date Modified
+### Date Modified
 By default, daux.io will display the last modified time as reported by the system underneath the title for each document. To disable this, change the option in your config.json to false.
 
 ```json
@@ -258,7 +258,7 @@ By default, daux.io will display the last modified time as reported by the syste
 }
 ```
 
-###Timezone
+### Timezone
 If your server does not have a default timezone set in php.ini, it may return errors when it tries to generate the last modified date/time for docs. To fix these errors, specify a timezone in your config file. Valid options are available in the [PHP Manual](http://php.net/manual/en/timezones.php).
 
 ```json
@@ -267,7 +267,7 @@ If your server does not have a default timezone set in php.ini, it may return er
 }
 ```
 
-###Inherit Index
+### Inherit Index
 This feature will instructs the navigation generator to seek the first available file to use when there is no index in a folder.
 
 ```json
@@ -278,7 +278,7 @@ This feature will instructs the navigation generator to seek the first available
 }
 ```
 
-###Multi-language
+### Multi-language
 Enables multi-language support which needs seperate directories for each language in `docs/` folder.
 
 ```json


### PR DESCRIPTION
Third-tier headings were not rendered correctly by GitHub because they were missing a space. I also removed some colons for consistency because all other H3 headings were not using colons.