### PR TITLE
add global checks in templates to prevent errors

### DIFF
--- a/templates/content.php
+++ b/templates/content.php
@@ -22,8 +22,7 @@
         <?= $page['content']; ?>
     </div>
 
-    <?php if ($params['html']['jump_buttons'] && (!empty($page['prev']) || !empty($page['next']))) {
-    ?>
+    <?php if ((!isset($params['html']['jump_buttons']) || $params['html']['jump_buttons']) && (!empty($page['prev']) || !empty($page['next']))) {?>
     <nav>
         <ul class="Pager">
             <?php if (!empty($page['prev'])) {

--- a/templates/home.php
+++ b/templates/home.php
@@ -27,8 +27,10 @@
             foreach ($page['entry_page'] as $key => $node) {
                 echo '<a href="' . $node . '" class="Button Button--primary Button--hero">' . $key . '</a>';
             }
-            foreach ($params['html']['buttons'] as $name => $link ) {
-                echo '<a href="' . $link . '" class="Button Button--secondary Button--hero">' . $name . '</a>';
+            if(isset($params['html']['buttons']) && is_array($params['html']['buttons'])) {
+                foreach ($params['html']['buttons'] as $name => $link ) {
+                    echo '<a href="' . $link . '" class="Button Button--secondary Button--hero">' . $name . '</a>';
+                }
             }
             ?>
             <div class="clearfix"></div>


### PR DESCRIPTION
There could be errors in templates while generating, if `buttons` or `jump_buttons` is not available, or in wrong type. These checks should filter these problems and prevent errors.

The behavior for `jump_buttons` is:

> Will be shown whenever `jump_buttons` is not set or `true`.

This will make it backwards compatible to old versions too ...

This will fix #458