### PR TITLE
Implement directory title rewrite in document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ You can nest folders any number of levels to get the exact structure you want. T
 
 If you'd prefer to keep your docs somewhere else (like outside of the daux.io root directory) you can specify your docs path in the `global.json` file.
 
+If you need change folder's title in document, you could create a `_index.md` at target folder, and change title property by [Front Matter](http://daux.io/Features/Front_Matter).
+
+```
+---
+title: You Custom Title
+---
+```
+
 ## Files
 
 The generator will look for Markdown files (`*.md` and `*.markdown`) inside the `docs` folder and any of the subfolders within `docs`.

--- a/libs/Tree/Directory.php
+++ b/libs/Tree/Directory.php
@@ -279,4 +279,22 @@ class Directory extends Entry implements \ArrayAccess, \IteratorAggregate
     {
         return new ArrayIterator($this->children);
     }
+
+    /**
+     * Use index title first.
+     * @return string
+     */
+    public function getTitle()
+    {
+        $indexPage = $this->getIndexPage();
+        if ($indexPage != null) {
+            $indexTitle = $indexPage->getTitle();
+            if ($indexTitle != null) {
+                return $indexTitle;
+            }
+        }
+
+        // If index has no any title yaml information, use directory default title.
+        return $this->title;
+    }
 }


### PR DESCRIPTION
Before use directory's default title, try find it's index title first.